### PR TITLE
Add SurveyJS sample page with custom component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# surveyjs-components
+# SurveyJS Custom Component Sample
+
+This project demonstrates how to create and use a custom component with SurveyJS.
+
+## Running the Sample Page
+
+1. Clone this repository.
+2. Open the `index.html` file in your web browser.
+
+## Using the Custom Component
+
+The custom component is defined in `js/custom-component.js`. It's a simple component that displays a message.
+
+To use it in a survey, add an element with `type: "custommessage"` to your survey JSON:
+
+```json
+{
+  "elements": [{
+    "type": "custommessage"
+  }]
+}
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>SurveyJS Custom Component</title>
+  <script src="https://unpkg.com/survey-jquery/survey.jquery.min.js"></script>
+  <link href="https://unpkg.com/survey-core/survey.min.css" type="text/css" rel="stylesheet">
+  <script src="js/custom-component.js"></script>
+</head>
+<body>
+  <div id="surveyContainer"></div>
+  <script>
+    const surveyJson = {
+      elements: [{
+        type: "custommessage"
+      }]
+    };
+
+    const survey = new Survey.Model(surveyJson);
+    $("#surveyContainer").Survey({ model: survey });
+  </script>
+</body>
+</html>

--- a/js/custom-component.js
+++ b/js/custom-component.js
@@ -1,0 +1,8 @@
+Survey.ComponentCollection.Instance.add({
+  name: "custommessage",
+  title: "Custom Message",
+  questionJSON: {
+    type: "html",
+    html: "<h1>This is a custom component!</h1>"
+  }
+});


### PR DESCRIPTION
This commit introduces a sample SurveyJS page (`index.html`) that demonstrates the use of a custom component.

The custom component (`js/custom-component.js`) is a simple example that displays a static message.

The `README.md` has been updated with instructions on how to run the sample and use the custom component.