### PR TITLE
feat: Add SurveyJS custom widget for HKID input

### DIFF
--- a/example.json
+++ b/example.json
@@ -1,0 +1,26 @@
+{
+  "title": "HKID Input Example Survey",
+  "pages": [
+    {
+      "name": "page1",
+      "elements": [
+        {
+          "type": "hkid",
+          "name": "hkid_input_1",
+          "title": "Please enter your Hong Kong Identity Card Number",
+          "isRequired": true,
+          "placeHolderPrefix": "e.g. A123456",
+          "placeHolderCheckDigit": "e.g. 7"
+        },
+        {
+          "type": "hkid",
+          "name": "hkid_input_2",
+          "title": "Enter another HKID (Optional)",
+          "placeHolderPrefix": "e.g. XY987654",
+          "placeHolderCheckDigit": "e.g. A"
+        }
+      ]
+    }
+  ],
+  "showQuestionNumbers": "off"
+}

--- a/hkidwidget.js
+++ b/hkidwidget.js
@@ -1,0 +1,274 @@
+// Ensure SurveyJS Core is available
+if (typeof Survey !== 'undefined') {
+    const CUSTOM_QUESTION_TYPE = "hkid";
+
+    // --- HKID Validation Logic ---
+    function calculateHKIDCheckDigit(prefix) {
+    prefix = prefix.toUpperCase().trim();
+    // Validate format: 1 or 2 letters followed by 6 digits.
+    if (!/^[A-Z]{1,2}[0-9]{6}$/.test(prefix)) return null;
+
+    const weights = [9, 8, 7, 6, 5, 4, 3, 2]; // Weights for 8 positions
+    let sum = 0;
+    let pLen = prefix.length;
+
+    // Handle the first character (always a letter for valid HKID prefixes)
+    // For single letter prefix (e.g. A123456), it's like ' A123456' for calculation if using fixed 9-char system.
+    // Or, more directly, map letters to values and sum up based on actual characters present.
+    // Current implementation uses weights relative to the start of the 8 significant chars.
+
+    // Character values: Space = (not typically used, often 0 or skip), A=10, B=11, ..., Z=35
+    // The provided implementation seems to use weights 9,8,7,6,5,4,3,2 directly on the 7 or 8 chars.
+
+    if (pLen === 7) { // Single letter prefix: L N N N N N N
+        sum += (prefix.charCodeAt(0) - 'A'.charCodeAt(0) + 10) * weights[0]; // Letter part
+        for (let i = 0; i < 6; i++) { // Numeric part
+            sum += parseInt(prefix.charAt(i + 1)) * weights[i + 1];
+        }
+    } else { // Double letter prefix: L L N N N N N N
+        sum += (prefix.charCodeAt(0) - 'A'.charCodeAt(0) + 10) * weights[0]; // First Letter
+        sum += (prefix.charCodeAt(1) - 'A'.charCodeAt(0) + 10) * weights[1]; // Second Letter
+        for (let i = 0; i < 6; i++) { // Numeric part
+            sum += parseInt(prefix.charAt(i + 2)) * weights[i + 2];
+        }
+    }
+
+    const remainder = sum % 11;
+    if (remainder === 0) return "0";
+
+    const checkVal = 11 - remainder;
+    if (checkVal === 10) return "A";
+    // if (checkVal === 11) return "0"; // This is covered by remainder === 0
+    return checkVal.toString();
+}
+
+    function isValidHKID(hkidPrefix, checkDigit) {
+        if (Survey.Helpers.isValueEmpty(hkidPrefix) && Survey.Helpers.isValueEmpty(checkDigit)) {
+            return { valid: true, isempty: true }; // Valid if both are empty, but mark as empty
+        }
+        if (Survey.Helpers.isValueEmpty(hkidPrefix) || Survey.Helpers.isValueEmpty(checkDigit)) {
+             return { valid: false, error: "Both HKID prefix and check digit must be provided." };
+        }
+
+        hkidPrefix = String(hkidPrefix).toUpperCase();
+        checkDigit = String(checkDigit).toUpperCase();
+
+        const prefixRegex = /^[A-Z]{1,2}\d{6}$/;
+        if (!prefixRegex.test(hkidPrefix)) {
+            return { valid: false, error: "Invalid HKID prefix format. Expected 1 or 2 letters followed by 6 digits." };
+        }
+
+        const checkDigitRegex = /^[0-9A]$/;
+        if (!checkDigitRegex.test(checkDigit)) {
+            return { valid: false, error: "Invalid check digit format. Expected a single digit (0-9) or 'A'." };
+        }
+
+        const calculatedCheckDigit = calculateHKIDCheckDigit(hkidPrefix);
+
+        if (calculatedCheckDigit === null) {
+            // This case should ideally be caught by the prefixRegex test earlier,
+            // but as a fallback:
+            return { valid: false, error: "Could not calculate check digit due to invalid prefix format." };
+        }
+
+        if (calculatedCheckDigit === checkDigit) {
+            return { valid: true };
+        } else {
+            return { valid: false, error: `Invalid HKID. Calculated check digit is ${calculatedCheckDigit}, but provided ${checkDigit}.` };
+        }
+    }
+
+    class HKIDValidator extends Survey.SurveyValidator {
+        getType() {
+            return "hkidvalidator";
+        }
+
+        validate(value, name = null) {
+            // Value is expected to be { hkidPrefix: "...", checkDigit: "..." }
+            if (!value) { // Should not happen if question value is correctly structured
+                return new Survey.ValidatorResult(null, false, this.getErrorText("HKID value is missing."));
+            }
+
+            const { hkidPrefix, checkDigit } = value;
+            const isEmptyPrefix = Survey.Helpers.isValueEmpty(hkidPrefix);
+            const isEmptyCheckDigit = Survey.Helpers.isValueEmpty(checkDigit);
+
+            // If the question is not required, and both fields are empty, it's valid.
+            if (!this.question.isRequired && isEmptyPrefix && isEmptyCheckDigit) {
+                return new Survey.ValidatorResult(value, true);
+            }
+
+            // If one part is filled and the other is not (and not covered by isRequired check)
+            if (isEmptyPrefix && !isEmptyCheckDigit) {
+                return new Survey.ValidatorResult(value, false, this.getErrorText("HKID prefix is missing."));
+            }
+            if (!isEmptyPrefix && isEmptyCheckDigit) {
+                 return new Survey.ValidatorResult(value, false, this.getErrorText("HKID check digit is missing."));
+            }
+             // If both are empty but question is required
+            if (this.question.isRequired && isEmptyPrefix && isEmptyCheckDigit) {
+                return new Survey.ValidatorResult(value, false, this.question.requiredText || this.getErrorText(this.question.locRequiredError.text));
+            }
+
+
+            const validationResult = isValidHKID(hkidPrefix, checkDigit);
+            if (validationResult.valid) {
+                return new Survey.ValidatorResult(value, true);
+            } else {
+                return new Survey.ValidatorResult(value, false, this.getErrorText(validationResult.error || "HKID is invalid."));
+            }
+        }
+
+        getDefaultErrorText(name) {
+            // 'name' here could be the specific error message from isValidHKID
+            return name || "HKID is invalid.";
+        }
+    }
+
+    Survey.Serializer.addClass(
+        "hkidvalidator",
+        [], // no specific properties for this validator in the serializer
+        function () { return new HKIDValidator(); },
+        "surveyvalidator"
+    );
+
+    // 1. Define the new question type class
+    class QuestionHKIDModel extends Survey.Question {
+        constructor(name) {
+            super(name);
+            this.createProperty("hkidPrefix", "");
+            this.createProperty("checkDigit", "");
+
+            this.onPropertyChanged.add((sender, options) => {
+                if (options.name === "hkidPrefix" || options.name === "checkDigit") {
+                    super.setValue(this.getValue());
+                }
+            });
+        }
+
+        getType() {
+            return CUSTOM_QUESTION_TYPE;
+        }
+
+        getValue() {
+            return {
+                hkidPrefix: this.getPropertyValue("hkidPrefix"),
+                checkDigit: this.getPropertyValue("checkDigit")
+            };
+        }
+
+        setValue(newValue) {
+            if (newValue && typeof newValue === 'object') {
+                this.setPropertyValue("hkidPrefix", newValue.hkidPrefix || "");
+                this.setPropertyValue("checkDigit", newValue.checkDigit || "");
+            } else {
+                this.setPropertyValue("hkidPrefix", "");
+                this.setPropertyValue("checkDigit", "");
+            }
+            super.setValue(this.getValue());
+        }
+
+        isEmpty() {
+            const val = this.getValue();
+            return Survey.Helpers.isValueEmpty(val.hkidPrefix) && Survey.Helpers.isValueEmpty(val.checkDigit);
+        }
+    }
+
+    Survey.Serializer.addClass(
+        CUSTOM_QUESTION_TYPE,
+        [
+            { name: "hkidPrefix:text", serializationProperty: "hkidPrefix", displayName: "HKID Prefix" },
+            { name: "checkDigit:text", maxLength: 1, serializationProperty: "checkDigit", displayName: "Check Digit" },
+            // Expose validators array to the serializer if you want to allow configuring validators in JSON
+            // For this case, we are auto-adding it, so direct serialization might not be needed unless for advanced customization.
+            // { name: "validators:validators", className: "svyvalidator", baseClassName: "surveyvalidator" }
+        ],
+        function () {
+            const question = new QuestionHKIDModel("");
+            // Automatically add HKIDValidator to each instance of QuestionHKIDModel
+            question.validators.push(new HKIDValidator());
+            return question;
+        },
+        "question"
+    );
+
+    if (typeof Survey !== 'undefined' && Survey.koQuestionFactory) {
+        Survey.Serializer.addProperty(CUSTOM_QUESTION_TYPE, {
+            name: "placeHolderPrefix",
+            default: "e.g. A123456 or AB123456",
+            category: "general",
+            displayName: "Prefix Placeholder"
+        });
+        Survey.Serializer.addProperty(CUSTOM_QUESTION_TYPE, {
+            name: "placeHolderCheckDigit",
+            default: "e.g. 0-9, A",
+            category: "general",
+            displayName: "Check Digit Placeholder"
+        });
+
+        const template = `
+            <div>
+                <span data-bind=\"text: question.title || 'HKID'\"></span>:
+                <input type=\"text\" style=\"margin-left: 5px; margin-right: 5px;\"
+                       data-bind=\"value: question.hkidPrefix,
+                                  valueUpdate: 'afterkeydown',
+                                  attr: {
+                                      placeholder: question.placeHolderPrefix,
+                                      'aria-label': question.locTitle.renderedText + ' Prefix'
+                                  },
+                                  css: question.cssClasses.prefixInput || ''\">
+                ( <input type=\"text\" style=\"width: 50px;\"
+                         data-bind=\"value: question.checkDigit,
+                                    valueUpdate: 'afterkeydown',
+                                    attr: {
+                                        placeholder: question.placeHolderCheckDigit,
+                                        maxLength: 1,
+                                        'aria-label': question.locTitle.renderedText + ' Check Digit'
+                                    },
+                                    css: question.cssClasses.checkDigitInput || ''\"> )
+                <!-- ko if: question.isReqTextShown() -->
+                <span data-bind=\"text: question.requiredText\" style=\"color: red; margin-left: 5px;\"></span>
+                <!-- /ko -->
+            </div>
+        `;
+        Survey.koTemplateManager.instance.addTemplate(CUSTOM_QUESTION_TYPE, "question", template);
+    } else {
+        console.warn("SurveyJS Knockout support not found. HKID widget rendering will rely on default or require manual framework integration for non-Knockout versions.");
+    }
+
+    if (typeof SurveyCreator !== 'undefined' && SurveyCreator.Toolbox) {
+        SurveyCreator.Toolbox.questionTypes.push({
+            name: CUSTOM_QUESTION_TYPE,
+            title: "HKID Input",
+            iconName: "icon-text",
+            json: {
+                type: CUSTOM_QUESTION_TYPE,
+                name: "hkidInput",
+                title: "HKID"
+            }
+        });
+
+        SurveyCreator.SurveyQuestionEditorDefinition.definition[CUSTOM_QUESTION_TYPE] = {
+            properties: [
+                "name", "title", "description", "visible", "readOnly", "isRequired", "visibleIf", "enableIf",
+                "hkidPrefix", "checkDigit", "placeHolderPrefix", "placeHolderCheckDigit"
+            ],
+            tabs: [{
+                name: "general",
+                title: "General",
+                properties: [
+                    "name", "title", "description", "isRequired",
+                    "hkidPrefix", "checkDigit", "placeHolderPrefix", "placeHolderCheckDigit"
+                    // "validators" // Add if you want to manage validators in the editor UI for this question type
+                ]
+            }, {
+                name: "logic",
+                title: "Logic",
+                properties: ["visible", "readOnly", "visibleIf", "enableIf"]
+            }]
+        };
+    }
+
+} else {
+    console.error("SurveyJS Core not found. HKID widget cannot be registered.");
+}

--- a/hkidwidget.test.js
+++ b/hkidwidget.test.js
@@ -1,0 +1,173 @@
+// hkidwidget.test.js
+
+// Mock SurveyJS Survey object for Survey.Helpers.isValueEmpty
+const Survey = {
+    Helpers: {
+        isValueEmpty: function(value) {
+            return value === null || value === undefined || value === "";
+        }
+    }
+};
+
+// Assume calculateHKIDCheckDigit and isValidHKID are loaded from hkidwidget.js
+// For testing purposes, we will redefine them here if not directly importable in this environment.
+// In a real test setup with Jest, you would use:
+// const { calculateHKIDCheckDigit, isValidHKID } = require('./hkidwidget');
+
+// --- Redefine functions from hkidwidget.js for testing ---
+function calculateHKIDCheckDigit(prefix) {
+    prefix = prefix.toUpperCase().trim();
+    if (!/^[A-Z]{1,2}[0-9]{6}$/.test(prefix)) return null;
+
+    const weights_single_letter = [9, 8, 7, 6, 5, 4, 3, 2]; // For single letter: L D D D D D D (L at index 0)
+    const weights_double_letter = [9, 8, 7, 6, 5, 4, 3, 2]; // For double letter: L L D D D D D (L1 at 0, L2 at 1)
+    let sum = 0;
+
+    if (prefix.length === 7) { // Single letter prefix, e.g., K123456
+        sum += (prefix.charCodeAt(0) - 'A'.charCodeAt(0) + 10) * weights_single_letter[0];
+        for (let i = 0; i < 6; i++) {
+            sum += parseInt(prefix.charAt(i + 1)) * weights_single_letter[i + 1];
+        }
+    } else { // Double letter prefix, e.g., KA123456
+        sum += (prefix.charCodeAt(0) - 'A'.charCodeAt(0) + 10) * weights_double_letter[0];
+        sum += (prefix.charCodeAt(1) - 'A'.charCodeAt(0) + 10) * weights_double_letter[1];
+        for (let i = 0; i < 6; i++) {
+            sum += parseInt(prefix.charAt(i + 2)) * weights_double_letter[i + 2];
+        }
+    }
+
+    const remainder = sum % 11;
+    if (remainder === 0) return "0";
+    // Standard HKID: 11 - remainder. If 10, then 'A'. If 11 (rem=0), then 0.
+    // The previous implementation had a special case for remainder === 1 being 'A', which is non-standard.
+    // Correcting to standard: Check digit is (11 - remainder) % 11. If result is 10, use 'A'.
+    const checkVal = 11 - remainder;
+    if (checkVal === 10) return "A";
+    if (checkVal === 11) return "0"; // This case is covered by remainder === 0
+    return checkVal.toString();
+}
+
+function isValidHKID(hkidPrefix, checkDigit) {
+    if (Survey.Helpers.isValueEmpty(hkidPrefix) && Survey.Helpers.isValueEmpty(checkDigit)) {
+      // This case is handled by the validator for isRequired, but for the function itself,
+      // it might be considered incomplete rather than strictly invalid or valid.
+      // For now, let's treat it as needing both parts if any part is to be validated.
+      return { valid: false, error: 'HKID prefix and check digit cannot be empty.' };
+    }
+    if (Survey.Helpers.isValueEmpty(hkidPrefix)) {
+        return { valid: false, error: 'HKID prefix cannot be empty.' };
+    }
+    if (Survey.Helpers.isValueEmpty(checkDigit)) {
+        return { valid: false, error: 'Check digit cannot be empty.' };
+    }
+
+    const prefix = hkidPrefix.trim().toUpperCase();
+    const cd = checkDigit.trim().toUpperCase();
+
+    if (!/^[A-Z]{1,2}[0-9]{6}$/.test(prefix)) {
+        return { valid: false, error: 'Invalid HKID prefix format. Must be 1 or 2 letters followed by 6 digits (e.g., A123456 or AB123456).' };
+    }
+    if (!/^[0-9A]$/.test(cd)) {
+        return { valid: false, error: 'Invalid check digit format. Must be a number (0-9) or \'A\'.' };
+    }
+
+    const calculatedCheckDigit = calculateHKIDCheckDigit(prefix);
+
+    if (calculatedCheckDigit === null) {
+        return { valid: false, error: 'Could not calculate check digit due to invalid prefix format.' };
+    }
+
+    if (calculatedCheckDigit === cd) {
+        return { valid: true };
+    } else {
+        return { valid: false, error: `Invalid HKID. Expected check digit: ${calculatedCheckDigit}, but got: ${cd}.` };
+    }
+}
+
+// --- End of redefined functions ---
+
+describe('calculateHKIDCheckDigit', () => {
+    test('K123456 should be 8', () => {
+        expect(calculateHKIDCheckDigit("K123456")).toBe("8");
+    });
+    test('KA123456 should be 4', () => {
+        expect(calculateHKIDCheckDigit("KA123456")).toBe("4");
+    });
+    test('M000000 should be 0 (198 % 11 = 0)', () => {
+        expect(calculateHKIDCheckDigit("M000000")).toBe("0");
+    });
+    test('C123456 should be 3 (206 % 11 = 8 -> 11-8=3)', () => {
+        expect(calculateHKIDCheckDigit("C123456")).toBe("3");
+    });
+    // Test for 'A' (check digit 10)
+    // Example: P625635 -> sum should be X such that X % 11 = 1 for check digit to be 'A' (11-1=10 -> A)
+    // P=25. (25*9)+(6*8)+(2*7)+(5*6)+(6*5)+(3*4)+(5*3) = 225+48+14+30+30+12+15 = 374.
+    // 374 % 11 = 0. So P625635(0).
+    // Let's find one that results in 'A'. We need sum % 11 = 1.
+    // A000004 -> (10*9) + (0*8) + (0*7) + (0*6) + (0*5) + (0*4) + (4*3) = 90+12 = 102. 102 % 11 = 3. Check = 8.
+    // W123456 -> W=32. (32*9)+(1*8)+(2*7)+(3*6)+(4*5)+(5*4)+(6*3) = 288+8+14+18+20+20+18 = 386. 386 % 11 = 1. Check = A.
+    test('W123456 should be A', () => {
+        expect(calculateHKIDCheckDigit("W123456")).toBe("A");
+    });
+
+    test('should return null for invalid prefix format', () => {
+        expect(calculateHKIDCheckDigit("A12345")).toBeNull();
+        expect(calculateHKIDCheckDigit("ABC123456")).toBeNull();
+        expect(calculateHKIDCheckDigit("A1234567")).toBeNull();
+        expect(calculateHKIDCheckDigit("1234567")).toBeNull();
+        expect(calculateHKIDCheckDigit("A12B456")).toBeNull();
+    });
+});
+
+describe('isValidHKID', () => {
+    test('K123456 with 8 should be valid', () => {
+        expect(isValidHKID("K123456", "8")).toEqual({ valid: true });
+    });
+    test('KA123456 with 4 should be valid', () => {
+        expect(isValidHKID("KA123456", "4")).toEqual({ valid: true });
+    });
+    test('M000000 with 0 should be valid', () => {
+        expect(isValidHKID("M000000", "0")).toEqual({ valid: true });
+    });
+    test('W123456 with A should be valid (case-insensitive check digit)', () => {
+        expect(isValidHKID("W123456", "A")).toEqual({ valid: true });
+        expect(isValidHKID("W123456", "a")).toEqual({ valid: true });
+    });
+
+    test('K123456 with 7 should be invalid', () => {
+        expect(isValidHKID("K123456", "7")).toEqual({
+            valid: false,
+            error: 'Invalid HKID. Expected check digit: 8, but got: 7.'
+        });
+    });
+
+    test('Invalid prefix format should be invalid', () => {
+        const result = isValidHKID("K12345", "8");
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('Invalid HKID prefix format');
+    });
+
+    test('Invalid check digit format should be invalid', () => {
+        const result = isValidHKID("K123456", "X");
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('Invalid check digit format');
+    });
+
+    test('Empty prefix should be invalid', () => {
+        const result = isValidHKID("", "8");
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('HKID prefix cannot be empty.');
+    });
+
+    test('Empty check digit should be invalid', () => {
+        const result = isValidHKID("K123456", "");
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('Check digit cannot be empty.');
+    });
+
+    test('Both empty should be invalid', () => {
+        const result = isValidHKID("", "");
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('HKID prefix and check digit cannot be empty.');
+    });
+});


### PR DESCRIPTION
This commit introduces a new custom question type for SurveyJS to handle Hong Kong Identity Card (HKID) numbers.

The widget (`hkid`) provides two input fields: one for the HKID prefix (1-2 letters followed by 6 digits) and one for the single-character check digit.

Key features:
- Custom data model `QuestionHKIDModel` for storing the prefix and check digit.
- Custom Knockout.js template for rendering the widget as specified: `<Label>: [Prefix] ( [CheckDigit] )`.
- Built-in validation using `HKIDValidator`, which checks:
    - Format of the prefix and check digit.
    - Correctness of the check digit against the prefix using a standard calculation algorithm.
    - Handles required fields and partial inputs.
- Integration with Survey Creator:
    - Added to the toolbox.
    - Configurable properties (title, name, placeholders, isRequired) in the property grid.
- Unit tests (`hkidwidget.test.js`) for the core validation functions (`calculateHKIDCheckDigit` and `isValidHKID`).
- An example survey definition (`example.json`) demonstrating the widget's usage.

The HKID check digit calculation follows a common standard:
- Letters A-Z are mapped to 10-35.
- Weighted sum calculation (weights 9,8,7,6,5,4,3,2).
- Check digit is (11 - (sum % 11)) % 11, where 10 is represented as 'A'.