### PR TITLE
feat: Create nameCombine SurveyJS component

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,11 +7,12 @@
   <script src="https://unpkg.com/survey-core/themes/index.min.js"></script>
   <script src="https://unpkg.com/survey-js-ui/survey-js-ui.min.js"></script>
   <link href="https://unpkg.com/survey-core/survey-core.min.css" type="text/css" rel="stylesheet">
-  <!--<script src="js/custom-component.js"></script>
+  <script src="js/custom-component.js"></script>
   <script src="js/surveyjs-als-component.js"></script>
   <script src="js/surveyjs-ethnic-component.js"></script>
-  <script src="js/surveyjs-hkid-component.js"></script>-->
-  <!--<script src="js/surveyjs-name-split.js"></script>-->
+  <script src="js/surveyjs-hkid-component.js"></script>
+  <script src="js/surveyjs-name-split.js"></script>
+  <script src="js/surveyjs-name-combine.js"></script>
 </head>
 <body>
   <div id="surveyContainer"></div>
@@ -19,9 +20,9 @@
     const surveyJson = {
       elements: [
         {
-          "type": "text",
-          "name": "nameInfo",
-          "title": "Enter your full name"
+          "type": "nameCombine",
+          "name": "name",
+          "title": "Please enter your name"
         }
       ]
     };

--- a/js/surveyjs-name-combine.js
+++ b/js/surveyjs-name-combine.js
@@ -1,0 +1,59 @@
+function initNameCombine(Survey) {
+  Survey.ComponentCollection.Instance.add({
+    name: "nameCombine",
+    title: "Name",
+    questionTitleTemplate: "{title}",
+    elementsJSON: [
+      {
+        type: "text",
+        name: "surname",
+        title: "Surname",
+        isRequired: true,
+      },
+      {
+        type: "text",
+        name: "givenname",
+        title: "Given Name",
+        isRequired: true,
+        startWithNewLine: false,
+      },
+      {
+        type: "text",
+        name: "fullname",
+        title: "Full Name",
+        readOnly: true,
+        startWithNewLine: false,
+      },
+    ],
+    onLoaded(question) {
+      const surnameQuestion = question.contentPanel.getQuestionByName("surname");
+      const givennameQuestion = question.contentPanel.getQuestionByName("givenname");
+      const fullnameQuestion = question.contentPanel.getQuestionByName("fullname");
+
+      const updateFullName = () => {
+        const surname = surnameQuestion.value || "";
+        const givenname = givennameQuestion.value || "";
+        const fullname = (givenname + " " + surname).trim();
+        fullnameQuestion.value = fullname;
+        // Set the composite question's value
+        question.value = {
+            surname: surname,
+            givenname: givenname,
+            fullname: fullname
+        };
+      };
+
+      surnameQuestion.registerFunctionOnPropertyValueChanged("value", updateFullName);
+      givennameQuestion.registerFunctionOnPropertyValueChanged("value", updateFullName);
+
+      // Initial update
+      updateFullName();
+    }
+  });
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = initNameCombine;
+} else if (typeof Survey !== "undefined") {
+  initNameCombine(Survey);
+}


### PR DESCRIPTION
This commit introduces a new SurveyJS composite component called 'nameCombine'.

The component includes two text input fields for 'surname' and 'givenname', and a read-only 'fullname' field. The 'fullname' field is automatically populated by concatenating the 'givenname' and 'surname' values.

The implementation follows SurveyJS best practices by using `elementsJSON` for declarative UI definition and the `onLoaded` lifecycle hook to manage dynamic updates.